### PR TITLE
Support mounting folders as read only

### DIFF
--- a/Cilicon/Config/DirectoryMountConfig.swift
+++ b/Cilicon/Config/DirectoryMountConfig.swift
@@ -5,15 +5,19 @@ struct DirectoryMountConfig: Decodable {
     let hostPath: String
     /// The folder name in /Volumes/My Shared Files/ that the directory should be mounted to.
     let guestFolder: String
+    /// Mount the folder as a read only volume.
+    let readOnly: Bool
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.hostPath = (try container.decode(String.self, forKey: .hostPath) as NSString).standardizingPath
         self.guestFolder = try container.decode(String.self, forKey: .guestFolder)
+        self.readOnly = try container.decodeIfPresent(Bool.self, forKey: .readOnly) ?? .init()
     }
     
     enum CodingKeys: CodingKey {
         case hostPath
         case guestFolder
+        case readOnly
     }
 }

--- a/Cilicon/Config/DirectoryMountConfig.swift
+++ b/Cilicon/Config/DirectoryMountConfig.swift
@@ -12,7 +12,7 @@ struct DirectoryMountConfig: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.hostPath = (try container.decode(String.self, forKey: .hostPath) as NSString).standardizingPath
         self.guestFolder = try container.decode(String.self, forKey: .guestFolder)
-        self.readOnly = try container.decodeIfPresent(Bool.self, forKey: .readOnly) ?? .init()
+        self.readOnly = try container.decodeIfPresent(Bool.self, forKey: .readOnly) ?? false
     }
     
     enum CodingKeys: CodingKey {

--- a/Cilicon/VMConfigHelper+RunConfig.swift
+++ b/Cilicon/VMConfigHelper+RunConfig.swift
@@ -34,7 +34,8 @@ extension VMConfigHelper {
             if !FileManager.default.fileExists(atPath: mountConfig.hostPath) {
                 try FileManager.default.createDirectory(atPath: mountConfig.hostPath, withIntermediateDirectories: true)
             }
-            let mountDirectory = VZSharedDirectory(url: URL(fileURLWithPath: mountConfig.hostPath), readOnly: false)
+            let mountDirectory = VZSharedDirectory(url: URL(fileURLWithPath: mountConfig.hostPath),
+                                                   readOnly: mountConfig.readOnly)
             directoriesToShare[mountConfig.guestFolder] = mountDirectory
         }
         

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ hardware:
 directoryMounts:
   - hostPath: ~/CI/VM Cache
     guestFolder: Cache
+    readOnly: false
 autoTransferImageVolume: /Volumes/Cilicon Drive
 numberOfRunsUntilHostReboot: 20
 editorMode: false


### PR DESCRIPTION
This adds an optional key to a directoryMount item that specifies the folder should be mounted as read only in the guest virtual machine. This allows providing a read only cache directory which can safely be mounted by multiple guests simultaneously.