### PR TITLE
Add `runnerName` config name to the GithubActionsProvisioner

### DIFF
--- a/Cilicon/Provisioner/Github Actions/GithubActionsProvisioner.swift
+++ b/Cilicon/Provisioner/Github Actions/GithubActionsProvisioner.swift
@@ -14,7 +14,7 @@ class GithubActionsProvisioner: Provisioner {
     }
     
     var runnerName: String {
-        Host.current().localizedName ?? "no-name"
+        config.runnerName ?? Host.current().localizedName ?? "no-name"
     }
     
     func provision(bundle: VMBundle) async throws {


### PR DESCRIPTION
Fix for #8. 

Allows the `runnerName` to be used inside the GithubActionsProvisioner.