### PR TITLE
Add run untagged registration attribute in GitLab Provisoner

### DIFF
--- a/Cilicon/Config/GitLabProvisionerConfig.swift
+++ b/Cilicon/Config/GitLabProvisionerConfig.swift
@@ -7,6 +7,8 @@ struct GitLabProvisionerConfig: Decodable {
     let url: URL
     /// The runner registration token, can be obtained in the GitLab runner UI
     let registrationToken: String
+    /// Specifies if the runner should handle untagged jobs
+    let run_untagged: Bool
     /// A list of tags to apply to the runner, comma-separated
     let tagList: String
 }

--- a/Cilicon/Config/GitLabProvisionerConfig.swift
+++ b/Cilicon/Config/GitLabProvisionerConfig.swift
@@ -8,7 +8,7 @@ struct GitLabProvisionerConfig: Decodable {
     /// The runner registration token, can be obtained in the GitLab runner UI
     let registrationToken: String
     /// Specifies if the runner should handle untagged jobs
-    let run_untagged: Bool
+    let runUntagged: Bool
     /// A list of tags to apply to the runner, comma-separated
     let tagList: String
 }

--- a/Cilicon/Provisioner/GitLab Runner/GitLabService.swift
+++ b/Cilicon/Provisioner/GitLab Runner/GitLabService.swift
@@ -31,7 +31,7 @@ extension GitLabService {
     func registerRunner() async throws -> RunnerRegistrationResponse {
         let registration = RunnerRegistration(registrationToken: config.registrationToken,
                                               description: config.name,
-                                              run_untagged: config.run_untagged,
+                                              run_untagged: config.runUntagged,
                                               tags: config.tagList.components(separatedBy: ","))
         let jsonData = try encode(registration)
         let (data, response) = try await postRequest(to: runnersURL(), jsonData: jsonData)

--- a/Cilicon/Provisioner/GitLab Runner/GitLabService.swift
+++ b/Cilicon/Provisioner/GitLab Runner/GitLabService.swift
@@ -31,6 +31,7 @@ extension GitLabService {
     func registerRunner() async throws -> RunnerRegistrationResponse {
         let registration = RunnerRegistration(registrationToken: config.registrationToken,
                                               description: config.name,
+                                              run_untagged: config.run_untagged,
                                               tags: config.tagList.components(separatedBy: ","))
         let jsonData = try encode(registration)
         let (data, response) = try await postRequest(to: runnersURL(), jsonData: jsonData)
@@ -108,11 +109,13 @@ extension GitLabService {
     private struct RunnerRegistration: Codable {
         let registrationToken: String
         let description: String
+        let run_untagged: Bool
         let tags: [String]
         
         enum CodingKeys: String, CodingKey {
             case registrationToken = "token"
             case description
+            case run_untagged
             case tags = "tag_list"
         }
     }


### PR DESCRIPTION
This adds an option to set or unset the GitLab Runner to run untagged jobs. [1]
If set to `false` the Runner will not pick any untagged jobs.

Will close Issue #17 🎫 

Setting `runUntagged` to `true`:
```
[...]
provisioner:
  type: gitlab
  config:
     [..]
     runUntagged: true
     tagList: "macos-ventura-cilicon"
```
<img width="699" alt="with_runUntagged_true" src="https://github.com/traderepublic/Cilicon/assets/887443/a72ec0c4-87ca-4734-9de5-6fef66360b2e">

Setting `RunUntagged` to `false`:
```
[...]
provisioner:
  type: gitlab
  config:
     [...]
     runUntagged: false
     tagList: "macos-ventura-cilicon"
```
<img width="611" alt="wit_runUntagged_false" src="https://github.com/traderepublic/Cilicon/assets/887443/d0b597d6-cf36-4f86-8a32-2717ec6c71bc">

`runUntagged` is not optional inside the GitLab config block at the moment, happy to get feedback how to implement that.

[1] https://docs.gitlab.com/ee/api/runners.html#register-a-new-runner
