### PR TITLE
Fix GitLab start.command to shut down the VM instead of rebooting it

### DIFF
--- a/VM Resources/Gitlab Runner/start.command
+++ b/VM Resources/Gitlab Runner/start.command
@@ -19,4 +19,4 @@ endpoint=$(cat "$endpoint_file")
 /usr/local/bin/gitlab-runner run-single -u $endpoint -t $token --executor shell --env "FF_RESOLVE_FULL_TLS_CHAIN=1" --max-builds 1
 
 # Shut down the VM after build is completed
-sudo shutdown -r now
+sudo shutdown -h now


### PR DESCRIPTION
`shutdown -r` reboots the VM instead of shutting it down, which defeats the point of Cilicon's ephemeral runner VMs.

This changes it to `-h` which does actually shut down the VM and allows reverting VM state to the snapshot.