### PR TITLE
Add support for dotfile config

### DIFF
--- a/Cilicon.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cilicon.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -112,8 +112,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "324bc65a28323660fad8a36a7a37f0c2c78eeb9a",
-        "version" : "2.55.0"
+        "revision" : "2d8e6ca36fe3e8ed74b0883f593757a45463c34d",
+        "version" : "2.53.0"
       }
     },
     {
@@ -130,8 +130,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams",
       "state" : {
-        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-        "version" : "5.0.6"
+        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
+        "version" : "5.0.5"
       }
     }
   ],

--- a/Cilicon/CiliconApp.swift
+++ b/Cilicon/CiliconApp.swift
@@ -43,7 +43,7 @@ struct CiliconApp: App {
                         sshCredentials: .init(username: "admin", password: "admin")
                     )
 
-                    try? YAMLEncoder().encode(config).write(toFile: ConfigManager.path, atomically: true, encoding: .utf8)
+                    try? YAMLEncoder().encode(config).write(toFile: ConfigManager.configPaths[0], atomically: true, encoding: .utf8)
                     restart()
                 }
             }

--- a/Cilicon/Config/ConfigManager.swift
+++ b/Cilicon/Config/ConfigManager.swift
@@ -2,16 +2,18 @@ import Foundation
 import Yams
 
 class ConfigManager {
-    static let path = NSHomeDirectory() + "/cilicon.yml"
+    static let configPaths = ["/cilicon.yml", "/.cilicon.yml"]
+        .map { NSHomeDirectory() + $0 }
+
     static var fileExists: Bool {
-        FileManager.default.fileExists(atPath: path)
+        configPaths.compactMap(FileManager.default.fileExists).contains(true)
     }
 
     let config: Config
 
     init() throws {
         let decoder = YAMLDecoder()
-        guard let data = FileManager.default.contents(atPath: Self.path) else {
+        guard let data = Self.configPaths.compactMap(FileManager.default.contents).first else {
             throw ConfigManagerError.fileCouldNotBeRead
         }
         self.config = try decoder.decode(Config.self, from: data)

--- a/Cilicon/Config/ConfigManager.swift
+++ b/Cilicon/Config/ConfigManager.swift
@@ -6,7 +6,7 @@ class ConfigManager {
         .map { NSHomeDirectory() + $0 }
 
     static var fileExists: Bool {
-        configPaths.compactMap(FileManager.default.fileExists).contains(true)
+        configPaths.map(FileManager.default.fileExists).contains(true)
     }
 
     let config: Config


### PR DESCRIPTION
This PR allows the user to either store their config as `.cilicon.yml` or `cilicon.yml`.
Adresses #29
