### PR TITLE
Pass advanced configuration to GitLab Runner

### DIFF
--- a/Cilicon/Config/GitLabProvisionerConfig.swift
+++ b/Cilicon/Config/GitLabProvisionerConfig.swift
@@ -17,6 +17,9 @@ struct GitLabProvisionerConfig: Decodable {
     /// Only used if `downloadLatest` is set to `true`
     /// Defaults to the latest macOS binary from GitLab's S3 bucket
     let downloadURL: String
+    /// An optional advanced configuration for the GitLab Runner, will be copied to the executor as `config.toml` file
+    /// - seealso: https://docs.gitlab.com/runner/configuration/advanced-configuration.html
+    let configToml: String?
 
     enum CodingKeys: CodingKey {
         case gitlabURL
@@ -25,6 +28,7 @@ struct GitLabProvisionerConfig: Decodable {
         case maxNumberOfBuilds
         case downloadLatest
         case downloadURL
+        case configToml
     }
 
     init(from decoder: Decoder) throws {
@@ -37,5 +41,6 @@ struct GitLabProvisionerConfig: Decodable {
         self.maxNumberOfBuilds = try container.decodeIfPresent(Int.self, forKey: .maxNumberOfBuilds) ?? 1
         self.downloadLatest = try container.decodeIfPresent(Bool.self, forKey: .downloadLatest) ?? true
         self.downloadURL = try container.decodeIfPresent(String.self, forKey: .downloadURL) ?? defaultDownloadURL
+        self.configToml = try container.decodeIfPresent(String.self, forKey: .configToml)
     }
 }

--- a/Cilicon/Config/GitLabProvisionerConfig.swift
+++ b/Cilicon/Config/GitLabProvisionerConfig.swift
@@ -17,7 +17,8 @@ struct GitLabProvisionerConfig: Decodable {
     /// Only used if `downloadLatest` is set to `true`
     /// Defaults to the latest macOS binary from GitLab's S3 bucket
     let downloadURL: String
-    /// An optional advanced configuration for the GitLab Runner, will be copied to the executor as `config.toml` file
+    /// Optional advanced configuration for the GitLab Runner, will be appended to the `config.toml` file after the preconfigured `[[runners]]` section.
+    /// The values for `url`, `token`, `executor` and `limit` are already configured using the values specified in the Cilicon configuration file and should not be duplicated in this field.
     /// - seealso: https://docs.gitlab.com/runner/configuration/advanced-configuration.html
     let configToml: String?
 

--- a/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
+++ b/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
@@ -11,7 +11,7 @@ class GitLabRunnerProvisioner: Provisioner {
     func provision(bundle: VMBundle, sshClient: SSHClient) async throws {
         var downloadCommands: [String] = []
 
-        await SSHLogger.shared.log(string: "Copying config.toml to VM".magentaBold)
+        await SSHLogger.shared.log(string: "Configuring GitLab Runner...".magentaBold)
         let copyConfigTomlCommand = """
         mkdir -p ~/.gitlab-runner
         rm -rf ~/.gitlab-runner/config.toml
@@ -25,13 +25,8 @@ class GitLabRunnerProvisioner: Provisioner {
         EOF
         exit 1
         """
-
-        do {
-            try await executeCommand(command: copyConfigTomlCommand, sshClient: sshClient)
-        } catch {
-            fatalError(error.localizedDescription)
-        }
-        await SSHLogger.shared.log(string: "Copied config.toml successfully".greenBold)
+        try await executeCommand(command: copyConfigTomlCommand, sshClient: sshClient)
+        await SSHLogger.shared.log(string: "Successfully configured GitLab Runner".greenBold)
 
         if config.downloadLatest {
             await SSHLogger.shared.log(string: "Downloading GitLab Runner Binary from Source".magentaBold)

--- a/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
+++ b/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
@@ -11,25 +11,47 @@ class GitLabRunnerProvisioner: Provisioner {
     func provision(bundle: VMBundle, sshClient: SSHClient) async throws {
         var downloadCommands: [String] = []
 
+        await SSHLogger.shared.log(string: "Copying config.toml to VM".magentaBold)
+        let copyConfigTomlCommand = """
+        mkdir -p ~/.gitlab-runner
+        rm -rf ~/.gitlab-runner/config.toml
+        cat <<'EOF' >> ~/.gitlab-runner/config.toml
+        [[runners]]
+          url = "\(config.gitlabURL)"
+          token = "\(config.runnerToken)"
+          executor = "\(config.executor)"
+          limit = \(config.maxNumberOfBuilds)
+        \(config.configToml ?? "")
+        EOF
+        exit 1
+        """
+
+        do {
+            try await executeCommand(command: copyConfigTomlCommand, sshClient: sshClient)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+        await SSHLogger.shared.log(string: "Copied config.toml successfully".greenBold)
+
         if config.downloadLatest {
-            await SSHLogger.shared.log(string: "[1;35mDownloading GitLab Runner Binary from Source[0m\n")
+            await SSHLogger.shared.log(string: "Downloading GitLab Runner Binary from Source".magentaBold)
             downloadCommands = [
                 "rm -rf gitlab-runner",
                 "curl -o gitlab-runner \(config.downloadURL)",
                 "sudo chmod +x gitlab-runner"
             ]
+            try await executeCommand(command: downloadCommands.joined(separator: " && "), sshClient: sshClient)
+            await SSHLogger.shared.log(string: "Downloaded GitLab Runner Binary from Source successfully".magentaBold)
+        } else {
+            await SSHLogger.shared.log(string: "Skipped downloading GitLab Runner Binary because downloadLatest is false".magentaBold)
         }
 
-        let runCommand = """
-            gitlab-runner run-single \
-                -u \(config.gitlabURL.absoluteString) \
-                -t \(config.runnerToken) \
-                --executor \(config.executor) \
-                --max-builds \(config.maxNumberOfBuilds)
-        """
+        let runCommand = "gitlab-runner run"
+        await SSHLogger.shared.log(string: "Starting GitLab Runner...".magentaBold)
+        try await executeCommand(command: runCommand, sshClient: sshClient)
+    }
 
-        let command = (downloadCommands + [runCommand]).joined(separator: " && ")
-
+    private func executeCommand(command: String, sshClient: SSHClient) async throws {
         let streamOutput = try await sshClient.executeCommandStream(command, inShell: true)
         for try await blob in streamOutput {
             switch blob {
@@ -40,4 +62,10 @@ class GitLabRunnerProvisioner: Provisioner {
             }
         }
     }
+}
+
+/// Shell output color values
+private extension String {
+    var greenBold: String { "\u{001B}[1;32m\(self)\u{001B}[0m\n" }
+    var magentaBold: String { "\u{001B}[1;35m\(self)\u{001B}[0m\n" }
 }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ provisioner:
     maxNumberOfBuilds: <MAX_BUILDS> # defaults to '1'
     downloadLatest: <DOWNLOAD_LATEST> # defaults to 'true'
     downloadURL: <DOWNLOAD_URL> # defaults to GitLab official S3 bucket
+    configToml: > # Advanced config as custom config.toml file to be appended to the basic config and copied to the runner.
+      <CONFIG_TOML>
 ```
 
 #### Buildkite Agent


### PR DESCRIPTION
Adds possibility to pass advanced `config.toml` configuration to GitLab Runner.

Resolves #36 