### PR TITLE
Fix silent failure on Virtualization error during VM startup

### DIFF
--- a/Cilicon/VMManager.swift
+++ b/Cilicon/VMManager.swift
@@ -82,6 +82,7 @@ class VMManager: NSObject, ObservableObject {
         }.value
     }
 
+    @MainActor
     private func setupAndRunVirtualMachine() async throws {
         if !config.editorMode {
             try await cloneBundle()
@@ -91,10 +92,9 @@ class VMManager: NSObject, ObservableObject {
         let virtualMachine = VZVirtualMachine(configuration: vmConfig)
         virtualMachine.delegate = self
 
-        Task { @MainActor in
-            vmState = .running(virtualMachine)
-            try await virtualMachine.start()
-        }
+        try await virtualMachine.start()
+        vmState = .running(virtualMachine)
+
         if config.editorMode {
             return
         }
@@ -117,9 +117,9 @@ class VMManager: NSObject, ObservableObject {
             for try await blob in streamOutput {
                 switch blob {
                 case let .stdout(stdout):
-                    await SSHLogger.shared.log(string: String(buffer: stdout))
+                    SSHLogger.shared.log(string: String(buffer: stdout))
                 case let .stderr(stderr):
-                    await SSHLogger.shared.log(string: String(buffer: stderr))
+                    SSHLogger.shared.log(string: String(buffer: stderr))
                 }
             }
         }
@@ -137,14 +137,14 @@ class VMManager: NSObject, ObservableObject {
             for try await blob in streamOutput {
                 switch blob {
                 case let .stdout(stdout):
-                    await SSHLogger.shared.log(string: String(buffer: stdout))
+                    SSHLogger.shared.log(string: String(buffer: stdout))
                 case let .stderr(stderr):
-                    await SSHLogger.shared.log(string: String(buffer: stderr))
+                    SSHLogger.shared.log(string: String(buffer: stderr))
                 }
             }
         }
 
-        await SSHLogger.shared.log(string: "---------- Shutting Down ----------\n")
+        SSHLogger.shared.log(string: "---------- Shutting Down ----------\n")
         try await client.close()
 
         Task { @MainActor in


### PR DESCRIPTION
Removes `Task` which silently swallowed errors in favor of running the whole function on the main actor.

Closes #37 