### PR TITLE
Add exit behavior concept to allow exiting after number of runs 

### DIFF
--- a/Cilicon/VMManager.swift
+++ b/Cilicon/VMManager.swift
@@ -173,8 +173,10 @@ class VMManager: NSObject, ObservableObject {
             NSApplication.shared.terminate(nil)
             return
         }
-        if let runsTilReboot = config.numberOfRunsUntilHostReboot, runCounter >= runsTilReboot {
-            AppleEvent.restart.perform()
+        if let runsTilExit = config.exitBehavior?.numberOfRuns, runCounter >= runsTilExit {
+            if let rebootAfterExit = config.exitBehavior?.reboot, rebootAfterExit {
+                AppleEvent.restart.perform()
+            }
             NSApplication.shared.terminate(nil)
             return
         }


### PR DESCRIPTION
I have a use case to exit Cilicon after a number of builds but not reboot the host machine.

This PR adds the concept of exitBehavior, which replaces the current config `NumberOfRunsUntilHostReboot`
This enables you to specify the number of runs after which to exit, and if you want the host to reboot.
I left the existing config variable in for backwards compatibility
