### PR TITLE
Log with OSLog

### DIFF
--- a/Cilicon.xcodeproj/project.pbxproj
+++ b/Cilicon.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		A9FDAB2129375D0200B8CA1F /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = A9FDAB2029375D0200B8CA1F /* Yams */; };
 		A9FDAB2329375E8100B8CA1F /* DirectoryMountConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FDAB2229375E8100B8CA1F /* DirectoryMountConfig.swift */; };
 		A9FDAB2429375E8100B8CA1F /* DirectoryMountConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FDAB2229375E8100B8CA1F /* DirectoryMountConfig.swift */; };
+		F91B8E952AF3D1B30094E352 /* Logger+Cilicon.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91B8E942AF3D1B30094E352 /* Logger+Cilicon.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -105,6 +106,7 @@
 		A9FDAB0F292E33F800B8CA1F /* Installer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Installer.entitlements; sourceTree = "<group>"; };
 		A9FDAB1C292E5A2E00B8CA1F /* NSSound+SystemSounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSSound+SystemSounds.swift"; sourceTree = "<group>"; };
 		A9FDAB2229375E8100B8CA1F /* DirectoryMountConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryMountConfig.swift; sourceTree = "<group>"; };
+		F91B8E942AF3D1B30094E352 /* Logger+Cilicon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+Cilicon.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,13 +203,13 @@
 				A9728DD42918F79000342A77 /* CiliconApp.swift */,
 				A9FC3D0F2A127BE900535E9C /* VMSource.swift */,
 				A9728DD62918F79000342A77 /* ContentView.swift */,
-				A97080732A03F688006E044D /* SSHLogger.swift */,
 				629EA1322A05A6BC00899D73 /* ANSIParser.swift */,
 				A9728DE32918F7C500342A77 /* VirtualMachineView.swift */,
 				A9728DE72918F7D000342A77 /* VMManager.swift */,
 				A9728E022918F9A800342A77 /* Provisioner */,
 				A9728E0C2918F9CF00342A77 /* AppleEvents */,
 				A9728DF52918F98500342A77 /* Config */,
+				F91B8E962AF3D1BE0094E352 /* Logging */,
 				A951BCD8292B966A00FFDACC /* VMConfigHelper+RunConfig.swift */,
 				A970806E2A03B999006E044D /* LeaseParser.swift */,
 				A9728DD82918F79100342A77 /* Assets.xcassets */,
@@ -284,6 +286,15 @@
 				A9FDAB0F292E33F800B8CA1F /* Installer.entitlements */,
 			);
 			path = Installer;
+			sourceTree = "<group>";
+		};
+		F91B8E962AF3D1BE0094E352 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				A97080732A03F688006E044D /* SSHLogger.swift */,
+				F91B8E942AF3D1B30094E352 /* Logger+Cilicon.swift */,
+			);
+			path = Logging;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -444,6 +455,7 @@
 				A9728E052918F9BF00342A77 /* Provisioner.swift in Sources */,
 				A9FDAB1D292E5A2E00B8CA1F /* NSSound+SystemSounds.swift in Sources */,
 				A9728E092918F9C600342A77 /* GitHubService.swift in Sources */,
+				F91B8E952AF3D1B30094E352 /* Logger+Cilicon.swift in Sources */,
 				0EBACEC6299287BF00A041C4 /* GitLabRunnerProvisioner.swift in Sources */,
 				A9728DFE2918F9A000342A77 /* HardwareConfig.swift in Sources */,
 				A9728E002918F9A000342A77 /* ProvisionerConfig.swift in Sources */,

--- a/Cilicon/ANSIParser.swift
+++ b/Cilicon/ANSIParser.swift
@@ -4,6 +4,7 @@ struct ANSIParser {
     typealias Color = NSColor
     typealias Font = NSFont
     static let fontName = "Andale Mono"
+    private static let regex = /\[[0-9;]+m/
 
     static let defaultFont = Font.monospacedSystemFont(ofSize: Font.systemFontSize, weight: .regular)
     static let defaultAttributes: [NSAttributedString.Key: Any] = [
@@ -11,7 +12,6 @@ struct ANSIParser {
     ]
 
     static func parse(_ log: String) -> AttributedString {
-        guard let regex = try? Regex(#"\[[0-9;]+m"#) else { return .init(log) }
         var result = AttributedString()
         let ranges = log.ranges(of: regex)
         /// Create copy of ranges offset by 1, playing a role of next
@@ -31,10 +31,15 @@ struct ANSIParser {
 
         /// Fallback in case failed to parse
         if result.characters.isEmpty {
-            result.append(AttributedString(log.replacing(regex, with: { _ in "" }), attributes: .init(Self.defaultAttributes)))
+            result.append(AttributedString(log.replacing(regex, with: ""), attributes: .init(Self.defaultAttributes)))
         }
 
         return result
+    }
+
+    /// Strips ANSI codes from the log
+    static func stripped(_ log: String) -> String {
+        log.replacing(regex, with: "")
     }
 
     private static func attributesFor(ansiCode: String) -> [NSAttributedString.Key: Any] {

--- a/Cilicon/Logging/Logger+Cilicon.swift
+++ b/Cilicon/Logging/Logger+Cilicon.swift
@@ -1,0 +1,9 @@
+import os.log
+
+extension Logger {
+    static let ciliconSubsystem = Bundle.main.bundleIdentifier ?? "com.traderepublic.cilicon"
+
+    init(category: String) {
+        self.init(subsystem: Logger.ciliconSubsystem, category: category)
+    }
+}

--- a/Cilicon/Logging/SSHLogger.swift
+++ b/Cilicon/Logging/SSHLogger.swift
@@ -1,8 +1,11 @@
 import Foundation
+import os.log
 
 @MainActor
 final class SSHLogger: ObservableObject {
     static let shared = SSHLogger()
+
+    private let osLogger = Logger(category: "SSH")
 
     private init() { }
 
@@ -25,6 +28,9 @@ final class SSHLogger: ObservableObject {
     func log(string: String) {
         /// Skip empty logs
         guard string.isNotBlank else { return }
+
+        osLogger.notice("\(ANSIParser.stripped(string), privacy: .public)")
+
         if log.isEmpty {
             log = [LogChunk(text: string)]
             return


### PR DESCRIPTION
# Motivation
Observing the "SSH" log of the Cilicon.app requires to login to the host machine via remote desktop or VNC, because the log is not accessible on the command line.

# Description
This PR logs all string that are logged to the "SSH" window also to the system log. Further its replaces all print statements with OSLog calls.

# Examples
Get past "SSH" output:
```console
log show --style compact --predicate 'subsystem=="com.traderepublic.cilicon" and category == "SSH"'
```

Get live "SSH" output:
```console
log stream --style compact --predicate 'subsystem=="com.traderepublic.cilicon" and category == "SSH"'
```

Get all log messages from the VMManager (including debug and info):
```console
log show --style compact --predicate 'subsystem=="com.traderepublic.cilicon"' --info -debug
```