### PR TITLE
Fix GitLab runner to restart after each execution

### DIFF
--- a/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
+++ b/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
@@ -41,7 +41,7 @@ class GitLabRunnerProvisioner: Provisioner {
             await SSHLogger.shared.log(string: "Skipped downloading GitLab Runner Binary because downloadLatest is false".magentaBold)
         }
 
-        let runCommand = "gitlab-runner run"
+        let runCommand = "gitlab-runner run-single -u \(config.gitlabURL) -t \(config.runnerToken) --executor \(config.executor) --max-builds \(config.maxNumberOfBuilds)"
         await SSHLogger.shared.log(string: "Starting GitLab Runner...".magentaBold)
         try await executeCommand(command: runCommand, sshClient: sshClient)
     }


### PR DESCRIPTION
Before the gitlab runner did not restart after successful/failed execution. The parameters are read from cmd and not the config.toml. The option: -c which is in v17.2 of documentation is not present in gitlab-runner 17.2 which is the option for reading parameters from the config.toml

Fix github issue #52