### PR TITLE
Pass config as launch argument to support different config file location

### DIFF
--- a/Cilicon/CiliconApp.swift
+++ b/Cilicon/CiliconApp.swift
@@ -3,23 +3,22 @@ import Yams
 
 @main
 struct CiliconApp: App {
-    @State private var vmSource: String = ""
 
     var body: some Scene {
         Window("Cilicon", id: "cihost") {
-            if ConfigManager.fileExists {
+            Group {
                 switch Result(catching: { try ConfigManager().config }) {
                 case let .success(config):
-                    let contentView = ContentView(config: config)
-                    AnyView(contentView)
+                    ContentView(config: config)
+                case let .failure(error) where error is ConfigManagerError:
+                    Text("No configuration file found.\n\n"
+                         + "Please refer to the documentation on Github to create a configuration and restart the Cilicon.\n"
+                         + "Try following: `open /Applications/Cilicon.app  --args -config-path User/<user>/cilicon.yml`")
                 case let .failure(error):
                     Text(String(describing: error))
                 }
-
-            } else {
-                Text("No configuration file found.\n\nPlease refer to the documentation on Github to create a configuration and restart the Cilicon.")
-                    .multilineTextAlignment(.center)
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }

--- a/Cilicon/Config/ConfigManager.swift
+++ b/Cilicon/Config/ConfigManager.swift
@@ -6,7 +6,7 @@ class ConfigManager {
     let config: Config
 
     /// Default config
-    static let fallbackConfig = ["/cilicon.yml", "/.cilicon.yml"]
+    static let fallbackConfigPath = ["/cilicon.yml", "/.cilicon.yml"]
         .map { NSHomeDirectory() + $0 }
         .filter(FileManager.default.fileExists).first
 
@@ -15,10 +15,8 @@ class ConfigManager {
 
         // Launch argument to config e.g. ~/cilicon.yml
         // If no launch argument is found. The default fallback config is used
-        guard let configPath = UserDefaults.standard.string(forKey: "config-path") ?? Self.fallbackConfig else {
-            throw ConfigManagerError.fileDoesNotExist
-        }
-        guard FileManager.default.fileExists(atPath: configPath) else {
+        guard let configPath = UserDefaults.standard.string(forKey: "config-path") ?? Self.fallbackConfigPath,
+              FileManager.default.fileExists(atPath: configPath) else {
             throw ConfigManagerError.fileDoesNotExist
         }
         guard let data = FileManager.default.contents(atPath: configPath) else {

--- a/Cilicon/Config/ConfigManager.swift
+++ b/Cilicon/Config/ConfigManager.swift
@@ -16,10 +16,10 @@ class ConfigManager {
         // Launch argument to config e.g. ~/cilicon.yml
         // If no launch argument is found. The default fallback config is used
         guard let configPath = UserDefaults.standard.string(forKey: "config-path") ?? Self.fallbackConfig else {
-            throw ConfigManagerError.fileNotExists
+            throw ConfigManagerError.fileDoesNotExist
         }
         guard FileManager.default.fileExists(atPath: configPath) else {
-            throw ConfigManagerError.fileNotExists
+            throw ConfigManagerError.fileDoesNotExist
         }
         guard let data = FileManager.default.contents(atPath: configPath) else {
             throw ConfigManagerError.fileCouldNotBeRead
@@ -30,5 +30,5 @@ class ConfigManager {
 
 enum ConfigManagerError: Error {
     case fileCouldNotBeRead
-    case fileNotExists
+    case fileDoesNotExist
 }

--- a/Cilicon/Config/ConfigManager.swift
+++ b/Cilicon/Config/ConfigManager.swift
@@ -2,18 +2,26 @@ import Foundation
 import Yams
 
 class ConfigManager {
-    static let configPaths = ["/cilicon.yml", "/.cilicon.yml"]
-        .map { NSHomeDirectory() + $0 }
-
-    static var fileExists: Bool {
-        configPaths.map(FileManager.default.fileExists).contains(true)
-    }
 
     let config: Config
 
+    /// Default config
+    static let fallbackConfig = ["/cilicon.yml", "/.cilicon.yml"]
+        .map { NSHomeDirectory() + $0 }
+        .filter(FileManager.default.fileExists).first
+
     init() throws {
         let decoder = YAMLDecoder()
-        guard let data = Self.configPaths.compactMap(FileManager.default.contents).first else {
+
+        // Launch argument to config e.g. ~/cilicon.yml
+        // If no launch argument is found. The default fallback config is used
+        guard let configPath = UserDefaults.standard.string(forKey: "config-path") ?? Self.fallbackConfig else {
+            throw ConfigManagerError.fileNotExists
+        }
+        guard FileManager.default.fileExists(atPath: configPath) else {
+            throw ConfigManagerError.fileNotExists
+        }
+        guard let data = FileManager.default.contents(atPath: configPath) else {
             throw ConfigManagerError.fileCouldNotBeRead
         }
         self.config = try decoder.decode(Config.self, from: data)
@@ -22,4 +30,5 @@ class ConfigManager {
 
 enum ConfigManagerError: Error {
     case fileCouldNotBeRead
+    case fileNotExists
 }


### PR DESCRIPTION
This PR adds the functionality to change the configuration location.

How to use:
open /Applications/Cilicon.app --args -config-path /Users/username/some-other-folder/cilicon.yml

If no argument is set it will search for the regular default paths which are:
/Users/username/cilicon.yml
/Users/username/.cilicon.yml