### PR TITLE
PTECH-5542: 2.2.3: Fix Gitlab, Update dependencies, Change toml option

### DIFF
--- a/Cilicon.xcodeproj/project.pbxproj
+++ b/Cilicon.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					A9728DD02918F79000342A77 = {
 						CreatedOnToolsVersion = 14.1;
@@ -583,7 +583,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.traderepublic.cilicon;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -617,7 +617,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.traderepublic.cilicon;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -656,7 +656,7 @@
 			repositoryURL = "https://github.com/jpsim/Yams/";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.1.2;
+				minimumVersion = 5.3.1;
 			};
 		};
 		A9E7A0992C257E9700B38458 /* XCRemoteSwiftPackageReference "Citadel" */ = {
@@ -664,7 +664,7 @@
 			repositoryURL = "https://github.com/orlandos-nl/Citadel/";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.2;
+				minimumVersion = 0.10.0;
 			};
 		};
 		A9E7A09C2C257EA400B38458 /* XCRemoteSwiftPackageReference "Swift-JWT" */ = {

--- a/Cilicon.xcodeproj/xcshareddata/xcschemes/Cilicon.xcscheme
+++ b/Cilicon.xcodeproj/xcshareddata/xcschemes/Cilicon.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Cilicon/CiliconApp.swift
+++ b/Cilicon/CiliconApp.swift
@@ -3,7 +3,6 @@ import Yams
 
 @main
 struct CiliconApp: App {
-
     var body: some Scene {
         Window("Cilicon", id: "cihost") {
             Group {
@@ -11,9 +10,11 @@ struct CiliconApp: App {
                 case let .success(config):
                     ContentView(config: config)
                 case let .failure(error) where error is ConfigManagerError:
-                    Text("No configuration file found.\n\n"
-                         + "Please refer to the documentation on Github to create a configuration and restart the Cilicon.\n"
-                         + "Try following: `open /Applications/Cilicon.app  --args -config-path User/<user>/cilicon.yml`")
+                    Text(
+                        "No configuration file found.\n\n"
+                            + "Please refer to the documentation on Github to create a configuration and restart the Cilicon.\n"
+                            + "Try following: `open /Applications/Cilicon.app  --args -config-path User/<user>/cilicon.yml`"
+                    )
                 case let .failure(error):
                     Text(String(describing: error))
                 }

--- a/Cilicon/Config/ConfigManager.swift
+++ b/Cilicon/Config/ConfigManager.swift
@@ -2,7 +2,6 @@ import Foundation
 import Yams
 
 class ConfigManager {
-
     let config: Config
 
     /// Default config

--- a/Cilicon/Config/GitLabProvisionerConfig.swift
+++ b/Cilicon/Config/GitLabProvisionerConfig.swift
@@ -17,12 +17,6 @@ struct GitLabProvisionerConfig: Decodable {
     /// Only used if `downloadLatest` is set to `true`
     /// Defaults to the latest macOS binary from GitLab's S3 bucket
     let downloadURL: String
-    /// Optional advanced configuration for the GitLab Runner, will be appended to the `config.toml` file after the preconfigured `[[runners]]`
-    /// section.
-    /// The values for `url`, `token`, `executor` and `limit` are already configured using the values specified in the Cilicon configuration file and
-    /// should not be duplicated in this field.
-    /// - seealso: https://docs.gitlab.com/runner/configuration/advanced-configuration.html
-    let configToml: String?
 
     enum CodingKeys: CodingKey {
         case gitlabURL
@@ -31,7 +25,6 @@ struct GitLabProvisionerConfig: Decodable {
         case maxNumberOfBuilds
         case downloadLatest
         case downloadURL
-        case configToml
     }
 
     init(from decoder: Decoder) throws {
@@ -44,6 +37,5 @@ struct GitLabProvisionerConfig: Decodable {
         self.maxNumberOfBuilds = try container.decodeIfPresent(Int.self, forKey: .maxNumberOfBuilds) ?? 1
         self.downloadLatest = try container.decodeIfPresent(Bool.self, forKey: .downloadLatest) ?? true
         self.downloadURL = try container.decodeIfPresent(String.self, forKey: .downloadURL) ?? defaultDownloadURL
-        self.configToml = try container.decodeIfPresent(String.self, forKey: .configToml)
     }
 }

--- a/Cilicon/Config/GitLabProvisionerConfig.swift
+++ b/Cilicon/Config/GitLabProvisionerConfig.swift
@@ -17,6 +17,11 @@ struct GitLabProvisionerConfig: Decodable {
     /// Only used if `downloadLatest` is set to `true`
     /// Defaults to the latest macOS binary from GitLab's S3 bucket
     let downloadURL: String
+    /// If this is set to true, the runner ignore the other runner-related configs
+    /// and run `./gitlab-runner run-single -c ./config.toml`.
+    /// You may use a `preRun` script to prepare your toml file.
+    /// Defaults to `false`
+    let useToml: Bool
 
     enum CodingKeys: CodingKey {
         case gitlabURL
@@ -25,6 +30,7 @@ struct GitLabProvisionerConfig: Decodable {
         case maxNumberOfBuilds
         case downloadLatest
         case downloadURL
+        case useToml
     }
 
     init(from decoder: Decoder) throws {
@@ -37,5 +43,6 @@ struct GitLabProvisionerConfig: Decodable {
         self.maxNumberOfBuilds = try container.decodeIfPresent(Int.self, forKey: .maxNumberOfBuilds) ?? 1
         self.downloadLatest = try container.decodeIfPresent(Bool.self, forKey: .downloadLatest) ?? true
         self.downloadURL = try container.decodeIfPresent(String.self, forKey: .downloadURL) ?? defaultDownloadURL
+        self.useToml = try container.decodeIfPresent(Bool.self, forKey: .useToml) ?? false
     }
 }

--- a/Cilicon/Config/GitLabProvisionerConfig.swift
+++ b/Cilicon/Config/GitLabProvisionerConfig.swift
@@ -17,11 +17,9 @@ struct GitLabProvisionerConfig: Decodable {
     /// Only used if `downloadLatest` is set to `true`
     /// Defaults to the latest macOS binary from GitLab's S3 bucket
     let downloadURL: String
-    /// If this is set to true, the runner ignore the other runner-related configs
-    /// and run `./gitlab-runner run-single -c ./config.toml`.
-    /// You may use a `preRun` script to prepare your toml file.
-    /// Defaults to `false`
-    let useToml: Bool
+    /// If this is set, the other runner related variables are ignored.
+    /// Instead, the toml file specified will be used to configure the runner.
+    let tomlPath: String?
 
     enum CodingKeys: CodingKey {
         case gitlabURL
@@ -30,7 +28,7 @@ struct GitLabProvisionerConfig: Decodable {
         case maxNumberOfBuilds
         case downloadLatest
         case downloadURL
-        case useToml
+        case tomlPath
     }
 
     init(from decoder: Decoder) throws {
@@ -43,6 +41,6 @@ struct GitLabProvisionerConfig: Decodable {
         self.maxNumberOfBuilds = try container.decodeIfPresent(Int.self, forKey: .maxNumberOfBuilds) ?? 1
         self.downloadLatest = try container.decodeIfPresent(Bool.self, forKey: .downloadLatest) ?? true
         self.downloadURL = try container.decodeIfPresent(String.self, forKey: .downloadURL) ?? defaultDownloadURL
-        self.useToml = try container.decodeIfPresent(Bool.self, forKey: .useToml) ?? false
+        self.tomlPath = try container.decodeIfPresent(String.self, forKey: .tomlPath)
     }
 }

--- a/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
+++ b/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
@@ -20,8 +20,8 @@ class GitLabRunnerProvisioner: Provisioner {
         } else {
             await SSHLogger.shared.log(string: "Skipped downloading GitLab Runner Binary because downloadLatest is false".magentaBold)
         }
-        if config.useToml {
-            commands.append("./gitlab-runner run-single -c ./config.toml")
+        if let tomlPath = config.tomlPath {
+            commands.append("./gitlab-runner run-single -c '\(tomlPath)'")
         } else {
             let registerCommand = """
             ./gitlab-runner run-single \

--- a/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
+++ b/Cilicon/Provisioner/GitLab Runner/GitLabRunnerProvisioner.swift
@@ -9,41 +9,24 @@ class GitLabRunnerProvisioner: Provisioner {
     }
 
     func provision(bundle: VMBundle, sshClient: SSHClient) async throws {
-        var downloadCommands: [String] = []
-
-        await SSHLogger.shared.log(string: "Configuring GitLab Runner...".magentaBold)
-        let copyConfigTomlCommand = """
-        mkdir -p ~/.gitlab-runner
-        rm -rf ~/.gitlab-runner/config.toml
-        cat <<'EOF' >> ~/.gitlab-runner/config.toml
-        [[runners]]
-          url = "\(config.gitlabURL)"
-          token = "\(config.runnerToken)"
-          executor = "\(config.executor)"
-          limit = \(config.maxNumberOfBuilds)
-        \(config.configToml ?? "")
-        EOF
-        exit 1
-        """
-        try await executeCommand(command: copyConfigTomlCommand, sshClient: sshClient)
-        await SSHLogger.shared.log(string: "Successfully configured GitLab Runner".greenBold)
-
         if config.downloadLatest {
-            await SSHLogger.shared.log(string: "Downloading GitLab Runner Binary from Source".magentaBold)
-            downloadCommands = [
-                "rm -rf gitlab-runner",
-                "curl -o gitlab-runner \(config.downloadURL)",
-                "sudo chmod +x gitlab-runner"
-            ]
-            try await executeCommand(command: downloadCommands.joined(separator: " && "), sshClient: sshClient)
-            await SSHLogger.shared.log(string: "Downloaded GitLab Runner Binary from Source successfully".magentaBold)
+            await SSHLogger.shared.log(string: "Downloading GitLab Runner Binary".magentaBold)
+            let downloadCommand = """
+            curl -o gitlab-runner \(config.downloadURL) && chmod +x gitlab-runner
+            """
+            try await executeCommand(command: downloadCommand, sshClient: sshClient)
+            await SSHLogger.shared.log(string: "Downloaded GitLab Runner Binary".magentaBold)
         } else {
             await SSHLogger.shared.log(string: "Skipped downloading GitLab Runner Binary because downloadLatest is false".magentaBold)
         }
-
-        let runCommand = "gitlab-runner run"
-        await SSHLogger.shared.log(string: "Starting GitLab Runner...".magentaBold)
-        try await executeCommand(command: runCommand, sshClient: sshClient)
+        let registerCommand = """
+        ./gitlab-runner run-single \
+        --token \(config.runnerToken) \
+        --url \(config.gitlabURL) \
+        --executor \(config.executor) \
+        --max-builds \(config.maxNumberOfBuilds)
+        """
+        try await executeCommand(command: registerCommand, sshClient: sshClient)
     }
 
     private func executeCommand(command: String, sshClient: SSHClient) async throws {

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ provisioner:
     maxNumberOfBuilds: <MAX_BUILDS> # defaults to '1'
     downloadLatest: <DOWNLOAD_LATEST> # defaults to 'true'. If 'false' it expects the binary to be present at the user's home directory
     downloadURL: <DOWNLOAD_URL> # defaults to GitLab official S3 bucket
-    useToml: <USE_TOML> # defaults to `false`. If `true` it ignores the other runner configurations and expects the user to have a toml file ready in the admin's home directory.
+    tomlPath: <PATH_TO_TOML> # defaults to `nil`. If set, it ignores the other runner related variables and passes the specified path to the runner executable
 ```
 
 #### Buildkite Agent

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
   • <a href="#-join-us">Join Us</a>
 </p>
 
-> [!CAUTION]
-> There seems to be an issue with swift-nio based SSH on macOS 15.X hosts. Please don't update your host OS if you rely on Cilicon for production CI. This issue only affects the host OS. Images may still be updated to 15.X.
+> [!WARNING]
+> There seems to be an issue with swift-nio based SSH on macOS 15.0-15.3.X. Please use macOS 15.4+ for a more reliable experience.
 
 <details><summary><h3>💥 What's new in 2.0?</h3></summary>
 We're excited to announce a new major update to Cilicon! Here's a summary of what's new:
@@ -67,7 +67,7 @@ For more information on all available settings see [Config.swift](/Cilicon/Confi
 To use the GitHub Actions provisioner you will need to [create and install a new GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) with `Self-hosted runners` `Read & Write` permissions on the organization level and download the private key file to be referenced in the configuration file.
 
 ``` yml
-source: oci://ghcr.io/cirruslabs/macos-sonoma-xcode:15.3
+source: oci://ghcr.io/cirruslabs/macos-runner:sequoia
 provisioner:
   type: github
   config:
@@ -82,7 +82,7 @@ To use the GitLab Runner provisioner you will need to [create a runner with an a
 Minimal example:
 
 ``` yml
-source: oci://ghcr.io/cirruslabs/macos-sonoma-xcode:15.3
+source: oci://ghcr.io/cirruslabs/macos-runner:sequoia
 provisioner:
   type: gitlab
   config:
@@ -93,7 +93,7 @@ provisioner:
 Full configuration:
 
 ``` yml
-source: oci://ghcr.io/cirruslabs/macos-sonoma-xcode:15.3
+source: oci://ghcr.io/cirruslabs/macos-runner:sequoia
 provisioner:
   type: gitlab
   config:
@@ -101,10 +101,8 @@ provisioner:
     runnerToken: <RUNNER_TOKEN>
     executor: <EXECUTOR> # defaults to 'shell'
     maxNumberOfBuilds: <MAX_BUILDS> # defaults to '1'
-    downloadLatest: <DOWNLOAD_LATEST> # defaults to 'true'
+    downloadLatest: <DOWNLOAD_LATEST> # defaults to 'true'. If 'false' it expects the binary to be present at the user's home directory
     downloadURL: <DOWNLOAD_URL> # defaults to GitLab official S3 bucket
-    configToml: > # Advanced config as custom config.toml file to be appended to the basic config and copied to the runner.
-      <CONFIG_TOML>
 ```
 
 #### Buildkite Agent
@@ -112,7 +110,7 @@ provisioner:
 To use the Buildkite Agent provisioner, simply set your agent token in the provisioner config.
 
 ``` yml
-source: oci://ghcr.io/cirruslabs/macos-sonoma-xcode:15.3
+source: oci://ghcr.io/cirruslabs/macos-runner:sequoia
 provisioner:
   type: buildkite
   config:
@@ -124,7 +122,7 @@ provisioner:
 If you want to run a script (e.g. to start a runner that's not natively supported), you may use the `script` provisioner.
 
 ``` yml
-source: oci://ghcr.io/cirruslabs/macos-sonoma-xcode:15.3
+source: oci://ghcr.io/cirruslabs/macos-runner:sequoia
 provisioner:
   type: script
   config:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ provisioner:
     maxNumberOfBuilds: <MAX_BUILDS> # defaults to '1'
     downloadLatest: <DOWNLOAD_LATEST> # defaults to 'true'. If 'false' it expects the binary to be present at the user's home directory
     downloadURL: <DOWNLOAD_URL> # defaults to GitLab official S3 bucket
+    useToml: <USE_TOML> # defaults to `false`. If `true` it ignores the other runner configurations and expects the user to have a toml file ready in the admin's home directory.
 ```
 
 #### Buildkite Agent


### PR DESCRIPTION
This PR should fix the GitLab runner related issues mentioned in #42, #53, #55.

- Simplify GitLab runner commands
- Allow overriding runner config by providing a toml file (this needs to be provided separately, either by building it into the image, or by running a `preRun` script

Other changes:
- Dependency update
- Readme update