### PR TITLE
PTECH-4940: Add dummy console device support

### DIFF
--- a/Cilicon/Config/Config.swift
+++ b/Cilicon/Config/Config.swift
@@ -13,7 +13,8 @@ struct Config: Codable {
         retryDelay: Int,
         sshCredentials: SSHCredentials,
         preRun: String? = nil,
-        postRun: String? = nil
+        postRun: String? = nil,
+        consoleDevices: [String] = []
     ) {
         self.provisioner = provisioner
         self.hardware = hardware
@@ -26,6 +27,7 @@ struct Config: Codable {
         self.sshCredentials = sshCredentials
         self.preRun = preRun
         self.postRun = postRun
+        self.consoleDevices = consoleDevices
     }
 
     /// Provisioner Configuration.
@@ -52,6 +54,8 @@ struct Config: Codable {
     let preRun: String?
     /// A command to run after the provisioning commands are run.
     let postRun: String?
+    /// A list of console device names that are going to be injected into the VM.
+    let consoleDevices: [String]
 
     enum CodingKeys: CodingKey {
         case provisioner
@@ -65,6 +69,7 @@ struct Config: Codable {
         case sshCredentials
         case preRun
         case postRun
+        case consoleDevices
     }
 
     init(from decoder: Decoder) throws {
@@ -82,6 +87,7 @@ struct Config: Codable {
         self.sshCredentials = try container.decodeIfPresent(SSHCredentials.self, forKey: .sshCredentials) ?? .default
         self.preRun = try container.decodeIfPresent(String.self, forKey: .preRun)
         self.postRun = try container.decodeIfPresent(String.self, forKey: .postRun)
+        self.consoleDevices = try container.decodeIfPresent([String].self, forKey: .consoleDevices) ?? []
     }
 }
 

--- a/Cilicon/VMConfigHelper+RunConfig.swift
+++ b/Cilicon/VMConfigHelper+RunConfig.swift
@@ -24,6 +24,15 @@ extension VMConfigHelper {
             virtualMachineConfiguration.audioDevices = [createAudioDeviceConfiguration()]
         }
         virtualMachineConfiguration.directorySharingDevices = try [createDirectorySharingConfiguration(config: config)]
+
+        for consoleDeviceConfig in config.consoleDevices {
+            let consolePort = VZVirtioConsolePortConfiguration()
+            consolePort.name = consoleDeviceConfig
+            let consoleDevice = VZVirtioConsoleDeviceConfiguration()
+            consoleDevice.ports[0] = consolePort
+            virtualMachineConfiguration.consoleDevices.append(consoleDevice)
+        }
+
         try virtualMachineConfiguration.validate()
 
         return virtualMachineConfiguration

--- a/CiliconTests/OCI/Config/ConfigTests.swift
+++ b/CiliconTests/OCI/Config/ConfigTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import Yams
+
+@testable import Cilicon
+
+final class ConfigTests: XCTestCase {
+    private var yamlDecoder: YAMLDecoder!
+
+    override func setUp() {
+        yamlDecoder = YAMLDecoder()
+    }
+
+    override func tearDown() {
+        yamlDecoder = nil
+    }
+
+    func test_decode_consoleDevices_notPresent_isEmptyArray() throws {
+        let yaml = fixtureConfig
+        let sut = try yamlDecoder.decode(Config.self, from: Data(yaml.utf8))
+
+        XCTAssertEqual(sut.consoleDevices, [])
+    }
+
+    func test_decode_consoleDevices_isPresent_isParsedCorrectly() throws {
+        let yaml = fixtureConfig.appending("""
+        consoleDevices:
+          - test-device
+          - test-device2
+        """)
+
+        let sut = try yamlDecoder.decode(Config.self, from: Data(yaml.utf8))
+        XCTAssertEqual(sut.consoleDevices, ["test-device", "test-device2"])
+    }
+}
+
+private extension ConfigTests {
+    var fixtureConfig: String {
+        """
+        source: oci://example.com/namespace/image_name:tag
+        provisioner:
+          type: github
+          config:
+            appId: 123456
+            organization: test-organization
+            runnerGroup: test-group
+            privateKeyPath: ~/github.pem
+
+        """
+    }
+}

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ provisioner:
     downloadLatest: <DOWNLOAD_LATEST> # defaults to 'true'. If 'false' it expects the binary to be present at the user's home directory
     downloadURL: <DOWNLOAD_URL> # defaults to GitLab official S3 bucket
     tomlPath: <PATH_TO_TOML> # defaults to `nil`. If set, it ignores the other runner related variables and passes the specified path to the runner executable
+consoleDevices:
+  - tart-version-cilicon
 ```
 
 #### Buildkite Agent
@@ -130,6 +132,17 @@ provisioner:
      run: |
      	echo "Hello World"
         sleep 10
+```
+
+#### Console Devices
+
+Cilicon supports injecting console devices into the VM configuration. This is particularly useful for compatibility with tools like [tart-guest-agent](https://github.com/cirruslabs/tart-guest-agent) which expect specific console devices to be present.
+
+To add console devices, use the `consoleDevices` field in your configuration:
+
+```yml
+consoleDevices:
+  - tart-version-cilicon
 ```
 
 ### 🔨 Setting Up the Host OS


### PR DESCRIPTION
- This adds the support to inject console devices
- The console devices are configurable:
   ```yaml
   consoleDevices:
     - foo-device
   ```

## Motivation
* The cirruslabs tart VMs have a `tart-guest-agent` daemon running.
* `tart-guest-agent --run-vdagent`  expects a `/dev/cu.tart-version-...` device https://github.com/cirruslabs/tart-guest-agent/blob/43606ef0d845ce790d9490331c3611833f50a9dc/internal/tart/tart.go#L18
, otherwise it tries to kill the agent via `unix.Kill(os.Getppid(), syscall.SIGTERM)` https://github.com/cirruslabs/tart-guest-agent/blob/43606ef0d845ce790d9490331c3611833f50a9dc/internal/command/root.go#L82C10-L82C50
* which reboots the whole machine.
The workaround for this would be to add a console device with prefix `tart-version-`. For example:
```yml
consoleDevices:
  - tart-version-cilicon
```
