### PR TITLE
PE-107324: Retry SSH connect with configurable max attempts; update dependencies

### DIFF
--- a/Cilicon.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cilicon.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/BigInt.git",
       "state" : {
-        "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
-        "version" : "5.3.0"
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kitura/BlueRSA.git",
       "state" : {
-        "revision" : "440f78db26d8bb073f29590f1c7bd31004da09ae",
-        "version" : "1.0.201"
+        "revision" : "f40325520344a966523b214394aa350132a6af68",
+        "version" : "1.0.203"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orlandos-nl/Citadel/",
       "state" : {
-        "revision" : "9ebd290b6697236e84a7e8ee8df5ee290c0d25ee",
-        "version" : "0.7.2"
+        "revision" : "0e0830867f05837b391426c68171ea19b2981dbf",
+        "version" : "0.11.1"
       }
     },
     {
@@ -65,12 +65,21 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "f70225981241859eb4aa1a18a75531d26637c8cc",
+        "version" : "1.4.0"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -78,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
-        "version" : "1.1.1"
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
       }
     },
     {
@@ -87,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "067254c79435de759aeef4a6a03e43d087d61312",
-        "version" : "2.0.5"
+        "revision" : "334e682869394ee239a57dbe9262bff3cd9495bd",
+        "version" : "3.14.0"
       }
     },
     {
@@ -96,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kitura/Swift-JWT",
       "state" : {
-        "revision" : "f68ec28fbd90a651597e9e825ea7f315f8d52a1f",
-        "version" : "4.0.1"
+        "revision" : "2cf7ef3eeb0df84318c75662c257651285f8289f",
+        "version" : "4.0.2"
       }
     },
     {
@@ -105,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-        "version" : "1.5.4"
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
       }
     },
     {
@@ -114,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e5a216ba89deba84356bad9d4c2eab99071c745b",
-        "version" : "2.67.0"
+        "revision" : "1c30f0f2053b654e3d1302492124aa6d242cdba7",
+        "version" : "2.86.0"
       }
     },
     {
@@ -123,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Joannis/swift-nio-ssh.git",
       "state" : {
-        "revision" : "01e03b888734b03f1005b0ca329d7b5af50208e7",
-        "version" : "0.3.2"
+        "revision" : "b93961a2988607a756cbc21a811f406f27aa9ab6",
+        "version" : "0.3.4"
       }
     },
     {
@@ -132,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "f9266c85189c2751589a50ea5aec72799797e471",
-        "version" : "1.3.0"
+        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
+        "version" : "1.6.2"
       }
     },
     {
@@ -141,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams/",
       "state" : {
-        "revision" : "9234124cff5e22e178988c18d8b95a8ae8007f76",
-        "version" : "5.1.2"
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
       }
     }
   ],

--- a/Cilicon/Config/Config.swift
+++ b/Cilicon/Config/Config.swift
@@ -12,6 +12,7 @@ struct Config: Codable {
         autoTransferImageVolume: String? = nil,
         retryDelay: Int,
         sshCredentials: SSHCredentials,
+        sshConnectMaxRetries: Int,
         preRun: String? = nil,
         postRun: String? = nil,
         consoleDevices: [String] = []
@@ -25,6 +26,7 @@ struct Config: Codable {
         self.runnerName = runnerName
         self.retryDelay = retryDelay
         self.sshCredentials = sshCredentials
+        self.sshConnectMaxRetries = sshConnectMaxRetries
         self.preRun = preRun
         self.postRun = postRun
         self.consoleDevices = consoleDevices
@@ -50,6 +52,8 @@ struct Config: Codable {
     let retryDelay: Int
     /// Credentials to be used when connecting via SSH.
     let sshCredentials: SSHCredentials
+    /// Maximum number of retries for SSH connection attempts.
+    let sshConnectMaxRetries: Int
     /// A command to run before the provisioning commands are run.
     let preRun: String?
     /// A command to run after the provisioning commands are run.
@@ -67,6 +71,7 @@ struct Config: Codable {
         case runnerName
         case retryDelay
         case sshCredentials
+        case sshConnectMaxRetries
         case preRun
         case postRun
         case consoleDevices
@@ -85,6 +90,7 @@ struct Config: Codable {
         self.runnerName = try container.decodeIfPresent(String.self, forKey: .runnerName)
         self.retryDelay = try container.decodeIfPresent(Int.self, forKey: .retryDelay) ?? 5
         self.sshCredentials = try container.decodeIfPresent(SSHCredentials.self, forKey: .sshCredentials) ?? .default
+        self.sshConnectMaxRetries = try container.decodeIfPresent(Int.self, forKey: .sshConnectMaxRetries) ?? 10
         self.preRun = try container.decodeIfPresent(String.self, forKey: .preRun)
         self.postRun = try container.decodeIfPresent(String.self, forKey: .postRun)
         self.consoleDevices = try container.decodeIfPresent([String].self, forKey: .consoleDevices) ?? []

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ provisioner:
     downloadURL: <DOWNLOAD_URL> # defaults to GitLab official S3 bucket
     tomlPath: <PATH_TO_TOML> # defaults to `nil`. If set, it ignores the other runner related variables and passes the specified path to the runner executable
 consoleDevices:
-  - tart-version-cilicon
+  - tart-version-2
+sshConnectMaxRetries: <SSH_CONNECT_MAX_RETRIES> # defaults to 10
 ```
 
 #### Buildkite Agent
@@ -142,7 +143,16 @@ To add console devices, use the `consoleDevices` field in your configuration:
 
 ```yml
 consoleDevices:
-  - tart-version-cilicon
+  - tart-version-2
+```
+
+#### SSH Connect Retries
+After the VM starts, Cilicon connects to the guest over SSH to run any preRun/postRun commands and the provisioner. Some images may take a while before the SSH service is ready. Use `sshConnectMaxRetries` to control how many connection attempts Cilicon will make before giving up (default: 10).
+
+Example:
+
+```yml
+sshConnectMaxRetries: 20
 ```
 
 ### 🔨 Setting Up the Host OS


### PR DESCRIPTION
Some guest images take time before SSH is ready after boot, causing flaky provisioning. This PR adds a configurable retry mechanism for SSH connectivity and documents the new behavior. It also updates dependencies and fixes a console device example in the README.

### What changed
- VM
  - Add retry loop to wait for SSH readiness after boot, verifying with a simple command before proceeding.
  - Replace direct SSHClient.connect with createAndConnectSSHClient(ip:).
  - Add VMManagerError.sshConnectTimeout for exhausted attempts.
  - Use 5s connect timeout and 5s wait between attempts; no auto-reconnect.
- Config
  - New field: sshConnectMaxRetries with default 10 (backward compatible; decode fallback).
- Docs
  - Document sshConnectMaxRetries with example usage.
  - Fix consoleDevices example from tart-version-cilicon to tart-version-2.
- Dependencies
  - Update SwiftPM lockfile (Package.resolved).

### How to verify
- Default behavior
  - Use an existing config (without sshConnectMaxRetries). Start a VM and observe logs showing SSH retry attempts until success; provisioning proceeds (preRun/postRun/provisioner).
- Custom retries
  - Set sshConnectMaxRetries: 2 with an image that delays SSH; expect two attempts, then failure with “SSH Connect timeout”.
- Failure path
  - Use wrong SSH credentials; confirm retries occur and operation ends with sshConnectTimeout.
- Docs sanity
  - Confirm README examples are valid and consoleDevices: [tart-version-2] works.

Retry SSH connect with configurable max attempts; update dependencies


Internal Ticket: [PE-107324]

[PE-107324]: https://traderepublic.atlassian.net/browse/PE-107324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ