### PR TITLE
PTECH-5532: Add liveness probe support for GitHub Actions

### DIFF
--- a/Cilicon/Config/Config.swift
+++ b/Cilicon/Config/Config.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Config: Codable {
+struct Config: Decodable {
     init(
         provisioner: ProvisionerConfig,
         hardware: HardwareConfig,

--- a/Cilicon/Config/GithubProvisionerConfig.swift
+++ b/Cilicon/Config/GithubProvisionerConfig.swift
@@ -20,6 +20,9 @@ struct GithubProvisionerConfig: Decodable {
 
     let workFolder: String?
 
+    /// Liveness probe configuration for health monitoring.
+    let livenessProbe: LivenessProbeConfig
+
     let url: URL
 
     enum CodingKeys: CodingKey {
@@ -33,6 +36,7 @@ struct GithubProvisionerConfig: Decodable {
         case downloadLatest
         case repository
         case workFolder
+        case livenessProbe
     }
 
     init(from decoder: Decoder) throws {
@@ -51,5 +55,9 @@ struct GithubProvisionerConfig: Decodable {
         self.url = try container.decodeIfPresent(URL.self, forKey: .url) ?? fallbackURL
         self.downloadLatest = try container.decodeIfPresent(Bool.self, forKey: .downloadLatest) ?? true
         self.workFolder = try container.decodeIfPresent(String.self, forKey: .workFolder)
+        self.livenessProbe = try container
+            .decodeIfPresent(LivenessProbeConfig.self, forKey: .livenessProbe) ?? LivenessProbeConfig(
+                command: "pgrep -fl /Users/admin/actions-runner/run.sh"
+            )
     }
 }

--- a/Cilicon/Config/LivenessProbeConfig.swift
+++ b/Cilicon/Config/LivenessProbeConfig.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Configuration for liveness probe that monitors VM health
+struct LivenessProbeConfig: Decodable {
+    private static let defaultInterval: TimeInterval = 30
+    private static let defaultDelay: TimeInterval = 60
+
+    /// Shell command to execute for health check
+    let command: String
+    /// Interval  between probe checks
+    let interval: TimeInterval
+    /// Initial delay before starting probes
+    let delay: TimeInterval
+
+    enum CodingKeys: CodingKey {
+        case command
+        case interval
+        case delay
+    }
+
+    init(
+        command: String,
+        interval: TimeInterval = Self.defaultInterval,
+        delay: TimeInterval = Self.defaultDelay
+    ) {
+        self.command = command
+        self.interval = interval
+        self.delay = delay
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.command = try container.decode(String.self, forKey: .command)
+        self.interval = try container.decodeIfPresent(TimeInterval.self, forKey: .interval) ?? Self.defaultInterval
+        self.delay = try container.decodeIfPresent(TimeInterval.self, forKey: .delay) ?? Self.defaultDelay
+    }
+}

--- a/Cilicon/Config/ProvisionerConfig.swift
+++ b/Cilicon/Config/ProvisionerConfig.swift
@@ -49,3 +49,17 @@ enum ProvisionerConfig: Codable {
         case script
     }
 }
+
+// MARK: - Liveness probe
+
+extension ProvisionerConfig {
+    /// Liveness probe configuration for health monitoring, if supported by the provisioner.
+    var livenessProbe: LivenessProbeConfig? {
+        switch self {
+        case let .github(githubConfig):
+            githubConfig.livenessProbe
+        case .gitlab, .buildkite, .script:
+            nil
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -155,6 +155,34 @@ Example:
 sshConnectMaxRetries: 20
 ```
 
+#### Liveness Probe
+
+The liveness probe monitors the health of your VM during job execution. It periodically executes a shell command via SSH, and if the command fails (exits with non-zero status), Cilicon will automatically restart the VM. This helps ensure reliability by detecting and recovering from stuck or failed jobs.
+
+Configuration options:
+- `command`: Shell command to execute for health check (required)
+- `interval`: Time in seconds between health checks (default: 30)
+- `delay`: Initial delay in seconds before starting probes (default: 60)
+
+The probe will restart the VM if the command exits with a non-zero code. Temporary SSH connection errors are logged but won't trigger a restart.
+
+Example for GitHub Actions (with default values):
+
+```yml
+provisioner:
+  type: github
+  config:
+    appId: <APP_ID>
+    organization: <ORGANIZATION_SLUG>
+    privateKeyPath: ~/github.pem
+    livenessProbe:
+      command: "pgrep -fl /Users/admin/actions-runner/run.sh"
+      interval: 30
+      delay: 60
+```
+
+**Note:** The liveness probe is currently only supported for the GitHub Actions provisioner. By default, it checks if the GitHub Actions runner process is running. You can customize the probe command to check for other conditions specific to your setup.
+
 ### 🔨 Setting Up the Host OS
 It is recommended to use Cilicon on a macOS device fully dedicated to the task, ideally one that is [freshly restored](https://support.apple.com/en-gb/guide/apple-configurator-mac/apdd5f3c75ad/mac).
 


### PR DESCRIPTION
This adds liveness probe support, similar to [Kubernetes liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command).

# README

The liveness probe monitors the health of your VM during job execution. It periodically executes a shell command via SSH, and if the command fails (exits with non-zero status), Cilicon will automatically restart the VM. This helps ensure reliability by detecting and recovering from stuck or failed jobs.

Configuration options:
- `command`: Shell command to execute for health check (required)
- `interval`: Time in seconds between health checks (default: 30)
- `delay`: Initial delay in seconds before starting probes (default: 60)

The probe will restart the VM if the command exits with a non-zero code. Temporary SSH connection errors are logged but won't trigger a restart.

Example for GitHub Actions (with default values):

```yml
provisioner:
  type: github
  config:
    appId: <APP_ID>
    organization: <ORGANIZATION_SLUG>
    privateKeyPath: ~/github.pem
    livenessProbe:
      command: "pgrep -fl /Users/admin/actions-runner/run.sh"
      interval: 30
      delay: 60
```

**Note:** The liveness probe is currently only supported for the GitHub Actions provisioner. By default, it checks if the GitHub Actions runner process is running. You can customize the probe command to check for other conditions specific to your setup.

# Other

It also adds timestamps to the log output.

# Example

Guest machine was restarted during the night because the SSH connection between Cilicon.app and the VM dropped and  eventually the GitHub Actions runner script finished a job.
<img width="771" height="420" alt="Screenshot 2025-12-09 at 07 40 36" src="https://github.com/user-attachments/assets/508fc301-19af-4ef6-b106-830056c6af47" />

