### PR TITLE
PTECH-5542: Remove parentheses from release bundle zip file name

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -49,11 +49,11 @@ jobs:
           version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" Cilicon.xcarchive/Products/Applications/Cilicon.app/Contents/Info.plist)
           build=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" Cilicon.xcarchive/Products/Applications/Cilicon.app/Contents/Info.plist)
           if [ "${{ github.event_name }}" = "release" ]; then
-            echo "name=Cilicon_${version}_(${build})_unsigned.zip" >> $GITHUB_OUTPUT
+            echo "name=Cilicon_${version}_${build}_unsigned.zip" >> $GITHUB_OUTPUT
           else
             sha_short="${{ github.sha }}"
             sha_short="${sha_short:0:7}"
-            echo "name=Cilicon_${version}_(${build})_${sha_short}_unsigned.zip" >> $GITHUB_OUTPUT
+            echo "name=Cilicon_${version}_${build}_${sha_short}_unsigned.zip" >> $GITHUB_OUTPUT
           fi
 
       - name: Create ZIP Archive


### PR DESCRIPTION
Remove parentheses from release bundle zip file name because Github replaces them with dots:
<img width="306" height="109" alt="Screenshot 2025-12-10 at 12 22 03" src="https://github.com/user-attachments/assets/bdf22ede-45d7-4375-8624-9068c9feddf8" />
