### PR TITLE
PTECH-5542: Ad-hoc sign release to not drop required entitlements

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -29,10 +29,7 @@ jobs:
               -configuration Release \
               -archivePath Cilicon.xcarchive \
               -destination 'generic/platform=macOS' \
-              CODE_SIGN_IDENTITY='' \
-              CODE_SIGN_STYLE='Manual' \
-              CODE_SIGNING_REQUIRED=NO \
-              CODE_SIGNING_ALLOWED=NO \
+              CODE_SIGN_IDENTITY='-' \
               CURRENT_PROJECT_VERSION=${{ github.run_number }} \
               ARCHS=arm64 \
               ONLY_ACTIVE_ARCH=NO \
@@ -49,11 +46,11 @@ jobs:
           version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" Cilicon.xcarchive/Products/Applications/Cilicon.app/Contents/Info.plist)
           build=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" Cilicon.xcarchive/Products/Applications/Cilicon.app/Contents/Info.plist)
           if [ "${{ github.event_name }}" = "release" ]; then
-            echo "name=Cilicon_${version}_${build}_unsigned.zip" >> $GITHUB_OUTPUT
+            echo "name=Cilicon_${version}_${build}_adhoc.zip" >> $GITHUB_OUTPUT
           else
             sha_short="${{ github.sha }}"
             sha_short="${sha_short:0:7}"
-            echo "name=Cilicon_${version}_${build}_${sha_short}_unsigned.zip" >> $GITHUB_OUTPUT
+            echo "name=Cilicon_${version}_${build}_${sha_short}_adhoc.zip" >> $GITHUB_OUTPUT
           fi
 
       - name: Create ZIP Archive

--- a/Cilicon.xcodeproj/project.pbxproj
+++ b/Cilicon.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.traderepublic.cilicon;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -420,7 +420,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.traderepublic.cilicon;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
This fixes that the release bundle (e.g.  [Cilicon_2.4.0_20_unsigned.zip](https://github.com/traderepublic/Cilicon/releases/download/v2.4.0/Cilicon_2.4.0_20_unsigned.zip)) can not launch a VM. Error message:
> Invalid virtual machine configuration. The process doesn't have the "com.apple.security virtualization" entitlement.

## Before
```shell
$ codesign -dvv --entitlements - Cilicon.app       
Executable=/Users/steffen/Downloads/Cilicon_2.4.0_20_unsigned/Cilicon.app/Contents/MacOS/Cilicon
Identifier=Cilicon
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20400 size=63840 flags=0x20002(adhoc,linker-signed) hashes=1992+0 location=embedded
Signature=adhoc
Info.plist=not bound
TeamIdentifier=not set
Sealed Resources=none
Internal requirements=none
```

## After
(Artifact from https://github.com/traderepublic/Cilicon/actions/runs/20100608664 )
```shell
$ codesign -dvv --entitlements - Cilicon.app
Executable=/Users/steffen/Downloads/Cilicon_2.4.0_23_ca97a80_adhoc/Cilicon.app/Contents/MacOS/Cilicon
Identifier=com.traderepublic.cilicon
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20500 size=16282 flags=0x10002(adhoc,runtime) hashes=498+7 location=embedded
Signature=adhoc
Info.plist entries=22
TeamIdentifier=not set
Runtime Version=26.1.0
Sealed Resources version=2 rules=13 files=38
Internal requirements count=0 size=12
[Dict]
        [Key] com.apple.security.network.client
        [Value]
                [Bool] true
        [Key] com.apple.security.virtualization
        [Value]
                [Bool] true
```