### PR TITLE
Add Azure Pipelines provisioner

### DIFF
--- a/Cilicon/Config/AzurePipelinesProvisionerConfig.swift
+++ b/Cilicon/Config/AzurePipelinesProvisionerConfig.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct AzurePipelinesProvisionerConfig: Decodable {
+    /// The Azure DevOps organization URL, e.g. https://dev.azure.com/myorganization/
+    let url: URL
+    /// Personal Access Token with Agent Pools (read, manage) scope
+    let token: String
+    /// The agent pool name. Defaults to `Default`
+    let pool: String
+    /// The agent work directory. Defaults to `_work`
+    let workDirectory: String
+    /// The URL where the Azure Pipelines agent tarball can be downloaded.
+    /// Defaults to a macOS ARM64 agent from Microsoft's CDN.
+    /// Unfortunately, Microsoft does not offer a "latest" download URL.
+    let downloadURL: String
+
+    enum CodingKeys: CodingKey {
+        case url
+        case token
+        case pool
+        case workDirectory
+        case downloadURL
+    }
+
+    init(from decoder: Decoder) throws {
+        let defaultDownloadURL = "https://download.agent.dev.azure.com/agent/4.271.0/vsts-agent-osx-arm64-4.271.0.tar.gz"
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.url = try container.decode(URL.self, forKey: .url)
+        self.token = try container.decode(String.self, forKey: .token)
+        self.pool = try container.decodeIfPresent(String.self, forKey: .pool) ?? "Default"
+        self.workDirectory = try container.decodeIfPresent(String.self, forKey: .workDirectory) ?? "_work"
+        self.downloadURL = try container.decodeIfPresent(String.self, forKey: .downloadURL) ?? defaultDownloadURL
+    }
+}

--- a/Cilicon/Config/ProvisionerConfig.swift
+++ b/Cilicon/Config/ProvisionerConfig.swift
@@ -4,6 +4,7 @@ enum ProvisionerConfig: Codable {
     case github(GithubProvisionerConfig)
     case gitlab(GitLabProvisionerConfig)
     case buildkite(BuildkiteAgentProvisionerConfig)
+    case azurePipelines(AzurePipelinesProvisionerConfig)
     case script(ScriptProvisionerConfig)
 
     enum CodingKeys: CodingKey {
@@ -24,6 +25,9 @@ enum ProvisionerConfig: Codable {
         case .buildkite:
             let config = try container.decode(BuildkiteAgentProvisionerConfig.self, forKey: .config)
             self = .buildkite(config)
+        case .azurePipelines:
+            let config = try container.decode(AzurePipelinesProvisionerConfig.self, forKey: .config)
+            self = .azurePipelines(config)
         case .script:
             let config = try container.decode(ScriptProvisionerConfig.self, forKey: .config)
             self = .script(config)
@@ -46,6 +50,7 @@ enum ProvisionerConfig: Codable {
         case github
         case gitlab
         case buildkite
+        case azurePipelines
         case script
     }
 }
@@ -58,7 +63,7 @@ extension ProvisionerConfig {
         switch self {
         case let .github(githubConfig):
             githubConfig.livenessProbe
-        case .gitlab, .buildkite, .script:
+        case .gitlab, .buildkite, .azurePipelines, .script:
             nil
         }
     }

--- a/Cilicon/Provisioner/Azure Pipelines/AzurePipelinesProvisioner.swift
+++ b/Cilicon/Provisioner/Azure Pipelines/AzurePipelinesProvisioner.swift
@@ -1,0 +1,48 @@
+@preconcurrency import Citadel
+import Foundation
+
+class AzurePipelinesProvisioner: Provisioner {
+    let config: Config
+    let azurePipelinesConfig: AzurePipelinesProvisionerConfig
+
+    var agentName: String {
+        config.runnerName ?? Host.current().localizedName ?? "cilicon-agent"
+    }
+
+    init(config: Config, azurePipelinesConfig: AzurePipelinesProvisionerConfig) {
+        self.config = config
+        self.azurePipelinesConfig = azurePipelinesConfig
+    }
+
+    func provision(bundle: VMBundle, sshClient: SSHClient) async throws {
+        let commands: [String] = [
+            "mkdir -p ~/azpagent && cd ~/azpagent",
+            "curl -sL -o agent.tar.gz \(azurePipelinesConfig.downloadURL)",
+            "tar xzf agent.tar.gz",
+            "export VSO_AGENT_IGNORE=AZP_TOKEN,AZP_TOKEN_FILE",
+            """
+            ./config.sh --unattended \
+            --url \(azurePipelinesConfig.url) \
+            --auth pat \
+            --token \(azurePipelinesConfig.token) \
+            --pool \(azurePipelinesConfig.pool) \
+            --agent \(agentName) \
+            --work \(azurePipelinesConfig.workDirectory) \
+            --replace \
+            --acceptTeeEula
+            """,
+            "./run.sh --once",
+        ]
+
+        let command = commands.joined(separator: " && ")
+        let streamOutput = try await sshClient.executeCommandStream(command, inShell: true)
+        for try await blob in streamOutput {
+            switch blob {
+            case let .stdout(stdout):
+                await SSHLogger.shared.log(string: String(buffer: stdout))
+            case let .stderr(stderr):
+                await SSHLogger.shared.log(string: String(buffer: stderr))
+            }
+        }
+    }
+}

--- a/Cilicon/VMManager.swift
+++ b/Cilicon/VMManager.swift
@@ -31,6 +31,8 @@ final class VMManager: NSObject, ObservableObject {
             self.provisioner = GitLabRunnerProvisioner(config: gitLabConfig)
         case let .buildkite(buildkiteConfig):
             self.provisioner = BuildkiteAgentProvisioner(config: buildkiteConfig)
+        case let .azurePipelines(azurePipelinesConfig):
+            self.provisioner = AzurePipelinesProvisioner(config: config, azurePipelinesConfig: azurePipelinesConfig)
         case let .script(scriptConfig):
             self.provisioner = ScriptProvisioner(runBlock: scriptConfig.run)
         }


### PR DESCRIPTION
First of all, thanks for this great project!

This PR adds support for provisioning Azure Pipelines Agents using Cilicon. With the additions suggested to the code base, we are able to spawn CI runners using the following configuration file:

```yaml
source: IMAGESOURCE
runnerName: xerion-1
provisioner:
  type: azurePipelines
  config:
    url: https://dev.azure.com/OURORG/
    token: MYTOKEN
    pool: macOS
consoleDevices:
  - tart-version-2
```

The agent then starts successfully and handles builds:
<img width="2032" height="1072" alt="Screenshot 2026-04-20 at 11 30 39" src="https://github.com/user-attachments/assets/10335635-0a7c-42e8-8dbc-6c9e616d6e74" />

The automatic restart of the agent after each build works as expected.

Let me know if you'd like to see any changes to this PR before it can get merged.


Cheers,
Yannik